### PR TITLE
Feat fingerprinting viewport

### DIFF
--- a/plugins/default-browser-emulator/injected-scripts/window.screen.ts
+++ b/plugins/default-browser-emulator/injected-scripts/window.screen.ts
@@ -1,0 +1,2 @@
+proxyGetter(window.screen, 'availHeight', () => window.screen.height - (args.unAvailHeight || 0), true);
+proxyGetter(window.screen, 'availWidth', () => window.screen.width - (args.unAvailWidth || 0), true);

--- a/plugins/default-browser-emulator/lib/Viewports.ts
+++ b/plugins/default-browser-emulator/lib/Viewports.ts
@@ -56,8 +56,8 @@ export default class Viewports {
       positionY,
       screenWidth,
       screenHeight,
-      width: windowWidth,
-      height: windowHeight,
+      width: windowInnerWidth,
+      height: windowInnerHeight,
       deviceScaleFactor,
       isDefault: true,
     } as IViewport;

--- a/plugins/default-browser-emulator/lib/loadDomOverrides.ts
+++ b/plugins/default-browser-emulator/lib/loadDomOverrides.ts
@@ -86,12 +86,17 @@ export default function loadDomOverrides(
   if (voices?.length) {
     domOverrides.add('speechSynthesis.getVoices', { voices });
   }
+  const frame = data.windowFraming
   domOverrides.add('window.outerWidth', {
-    frameBorderWidth: data.windowFraming.frameBorderWidth,
+    frameBorderWidth: frame.frameBorderWidth,
   });
   domOverrides.add('window.outerHeight', {
-    frameBorderHeight: data.windowFraming.frameBorderHeight,
+    frameBorderHeight: frame.frameBorderHeight,
   });
+  domOverrides.add('window.screen', {
+      unAvailHeight: frame.screenGapTop + frame.screenGapBottom,
+      unAvailWidth: frame.screenGapLeft + frame.screenGapRight,
+  })
 
   return domOverrides;
 }


### PR DESCRIPTION
Two changes:
1. Changing viewPort to use innerWidth and innerHeight. When testing with this setup before the changes it was seen that the final outerWidth had this frameBorder applied twice resulting in a window size that was larger then the actual screen.
2. Adding a new dom override to also set available screen on window.screen, so it matches the behaviour of normal browsers.

Before:
<img width="468" alt="image" src="https://user-images.githubusercontent.com/116737867/217842236-711de4be-24bc-466a-bce6-02b7ded6d7f9.png">

After:
<img width="474" alt="image" src="https://user-images.githubusercontent.com/116737867/217841229-a040ece7-15ec-49bf-8cd6-6ea118aa9fda.png">
