### PR TITLE
prevent mitm proxy auth to be escaped prior to base64 encoding it

### DIFF
--- a/agent/mitm-socket/go/dialer_proxy_http.go
+++ b/agent/mitm-socket/go/dialer_proxy_http.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/tls"
 	"encoding/base64"
 	"errors"
@@ -26,8 +27,14 @@ func DialAddrViaHttpProxy(dialer net.Dialer, addr string, proxyUrl *url.URL, all
 	}
 
 	if proxyUrl.User != nil {
-		proxyAuth := proxyUrl.User.String()
-		connectReq.Header.Set("Proxy-Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(proxyAuth))))
+		authBuffer := bytes.NewBuffer()
+		authEncoder := base64.NewEncoder(base64.StdEncoding, authbuffer)
+		authEncoder.Write([]byte(proxyUrl.User.Username()))
+		if password, passwordSet := proxyUrl.User.Password(); passwordSet {
+			authEncoder.Write([]byte{':'})
+			authEncoder.Write([]byte(password))
+		}
+		connectReq.Header.Set("Proxy-Authorization", fmt.Sprintf("Basic %s", authBuffer.Bytes()))
 	}
 
 	conn, err := dialer.Dial("tcp", proxyHost)

--- a/agent/mitm-socket/go/dialer_proxy_http.go
+++ b/agent/mitm-socket/go/dialer_proxy_http.go
@@ -27,8 +27,8 @@ func DialAddrViaHttpProxy(dialer net.Dialer, addr string, proxyUrl *url.URL, all
 	}
 
 	if proxyUrl.User != nil {
-		authBuffer := bytes.NewBuffer()
-		authEncoder := base64.NewEncoder(base64.StdEncoding, authbuffer)
+		authBuffer := bytes.NewBuffer(nil)
+		authEncoder := base64.NewEncoder(base64.StdEncoding, authBuffer)
 		authEncoder.Write([]byte(proxyUrl.User.Username()))
 		if password, passwordSet := proxyUrl.User.Password(); passwordSet {
 			authEncoder.Write([]byte{':'})

--- a/agent/mitm-socket/go/dialer_proxy_http.go
+++ b/agent/mitm-socket/go/dialer_proxy_http.go
@@ -34,6 +34,7 @@ func DialAddrViaHttpProxy(dialer net.Dialer, addr string, proxyUrl *url.URL, all
 			authEncoder.Write([]byte{':'})
 			authEncoder.Write([]byte(password))
 		}
+		authEncoder.Close() // flush any partially written blocks
 		connectReq.Header.Set("Proxy-Authorization", fmt.Sprintf("Basic %s", authBuffer.Bytes()))
 	}
 

--- a/agent/mitm-socket/go/generate_cert.go
+++ b/agent/mitm-socket/go/generate_cert.go
@@ -80,11 +80,11 @@ func NewAuthority() (*x509.Certificate, *rsa.PrivateKey, error) {
 	certFromDisk, err := readCertFromDisk(caFile)
 
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		log.Printf("Error reading cert from disk", caFile, err)
+		log.Print("Error reading cert from disk", caFile, err)
 	} else if err == nil {
 		keyFromDisk, err := readPrivateKeyFromDisk(caKeyFile)
 		if err != nil {
-			log.Printf("Error reading private key from disk", caKeyFile, err)
+			log.Print("Error reading private key from disk", caKeyFile, err)
 		} else {
 			return certFromDisk, keyFromDisk, nil
 		}


### PR DESCRIPTION
<https://cs.opensource.google/go/go/+/refs/tags/go1.20:src/net/url/url.go;l=420-431> shows that the auth info (both username and password) gets escaped, which is undesirable as their escape is also escaping legit chars such as '!'.

This commits disables the escaping completly. We can also define our own escaping if you think this is useful, but I doubt that for our use case we really need to worry about this and can expect the user to pass in valid credentials. Escaping would either way not help here as you'll just replace one error (invalid chars) into another error (not authorized)