### PR TITLE
Feature/Allow-referrer-injection-in-goto

### DIFF
--- a/agent/main/lib/Page.ts
+++ b/agent/main/lib/Page.ts
@@ -297,6 +297,7 @@ export default class Page extends TypedEventEmitter<IPageLevelEvents> implements
     options?: { timeoutMs?: number; referrer?: string },
   ): Promise<IResourceMeta> {
     let formattedUrl: string;
+    let navigateOptions = {};
 
     try {
       formattedUrl = Url.format(new Url.URL(url), { unicode: true });
@@ -315,11 +316,16 @@ export default class Page extends TypedEventEmitter<IPageLevelEvents> implements
     if (options?.timeoutMs) {
       this.browserContext.resources.setNavigationConnectTimeoutMs(formattedUrl, options.timeoutMs);
     }
+    if (options?.referrer) {
+      navigateOptions = {
+        referrer: options?.referrer
+      };
+    }
 
     const timeoutMessage = `Timeout waiting for "tab.goto(${url})"`;
 
     const timer = new Timer(options?.timeoutMs ?? 30e3, this.waitTimeouts);
-    const loader = await timer.waitForPromise(this.navigate(formattedUrl), timeoutMessage);
+    const loader = await timer.waitForPromise(this.navigate(formattedUrl, navigateOptions), timeoutMessage);
     this.mainFrame.navigations.assignLoaderId(navigation, loader.loaderId);
 
     const resourceId = await timer.waitForPromise(


### PR DESCRIPTION
e# Why

Having brought this topic up qith @blakebyrnes in discord I decided to try tackle this to allow us to inject the referer in the goto method.

# Discussion

![image](https://user-images.githubusercontent.com/58665244/230854592-b226149c-c7a5-48ea-a7b3-5ac93ee98025.png)


# Summary of proposed solution.

Considering in the unblocked repo we have the referer available already in the navigate method:

![image](https://user-images.githubusercontent.com/58665244/230855051-6ba9c3f5-45e8-4757-afe8-422bd4eb642d.png)

All that is needed it simply collect and add it to the navigateOptions in order to send it to navigate method

It is essential that this PR works along with: https://github.com/ulixee/hero/pull/226
