### PR TITLE
fix: console leaking info

### DIFF
--- a/plugins/default-browser-emulator/injected-scripts/console.debug.ts
+++ b/plugins/default-browser-emulator/injected-scripts/console.debug.ts
@@ -1,3 +1,0 @@
-proxyFunction(console, 'debug', () => {
-  return undefined;
-});

--- a/plugins/default-browser-emulator/injected-scripts/console.ts
+++ b/plugins/default-browser-emulator/injected-scripts/console.ts
@@ -9,7 +9,7 @@ for (const logLevel of logLevels) {
   proxyFunction(console, logLevel, (target, thisArg, args) => {
     const safeArgs = args.map(arg => {
       if (typeof arg === 'object') {
-        return 'hiding arg';
+        return 'Object Logging Disabled by Hero Stealth';
       }
       return arg;
     });

--- a/plugins/default-browser-emulator/injected-scripts/console.ts
+++ b/plugins/default-browser-emulator/injected-scripts/console.ts
@@ -1,0 +1,16 @@
+const hideAllLogs = true;
+
+// Logging error on any of these levels triggers a getter, which could be proxied.
+// The same could technically be done for any object so to prevent detection here
+// we have to disable all console logging functionality, which is pretty annoying
+// and hopefully we find a better solution for this.
+
+const logLevels = ['trace', 'debug', 'info', 'warn', 'error', 'log'] as const;
+
+if (hideAllLogs) {
+  for (const logLevel of logLevels) {
+    proxyFunction(console, logLevel, () => {
+      return undefined;
+    });
+  }
+}

--- a/plugins/default-browser-emulator/injected-scripts/console.ts
+++ b/plugins/default-browser-emulator/injected-scripts/console.ts
@@ -1,16 +1,19 @@
-const hideAllLogs = true;
-
 // Logging error on any of these levels triggers a getter, which could be proxied.
 // The same could technically be done for any object so to prevent detection here
 // we have to disable all console logging functionality, which is pretty annoying
 // and hopefully we find a better solution for this.
-
 const logLevels = ['trace', 'debug', 'info', 'warn', 'error', 'log'] as const;
+const reflectCached = ReflectCached;
 
-if (hideAllLogs) {
-  for (const logLevel of logLevels) {
-    proxyFunction(console, logLevel, () => {
-      return undefined;
+for (const logLevel of logLevels) {
+  proxyFunction(console, logLevel, (target, thisArg, args) => {
+    const safeArgs = args.map(arg => {
+      if (typeof arg === 'object') {
+        return 'hiding arg';
+      }
+      return arg;
     });
-  }
+
+    return reflectCached.apply(target, thisArg, safeArgs);
+  });
 }

--- a/plugins/default-browser-emulator/injected-scripts/console.ts
+++ b/plugins/default-browser-emulator/injected-scripts/console.ts
@@ -1,7 +1,7 @@
 // Logging error on any of these levels triggers a getter, which could be proxied.
 // The same could technically be done for any object so to prevent detection here
-// we have to disable all console logging functionality, which is pretty annoying
-// and hopefully we find a better solution for this.
+// we use json stringify, so we ignore all of this dangerous logic while still
+// logging as much as possible of the original object.
 const logLevels = ['trace', 'debug', 'info', 'warn', 'error', 'log'] as const;
 const reflectCached = ReflectCached;
 
@@ -9,7 +9,7 @@ for (const logLevel of logLevels) {
   proxyFunction(console, logLevel, (target, thisArg, args) => {
     const safeArgs = args.map(arg => {
       if (typeof arg === 'object') {
-        return 'Object Logging Disabled by Hero Stealth';
+        return JSON.stringify(arg, null, 2);
       }
       return arg;
     });

--- a/plugins/default-browser-emulator/lib/loadDomOverrides.ts
+++ b/plugins/default-browser-emulator/lib/loadDomOverrides.ts
@@ -82,7 +82,7 @@ export default function loadDomOverrides(
     domOverrides.add('navigator.plugins', parseNavigatorPlugins(windowNavigator.navigator));
   }
   domOverrides.add('WebGLRenderingContext.prototype.getParameter', deviceProfile.webGlParameters);
-  domOverrides.add('console.debug');
+  domOverrides.add('console');
   domOverrides.add('HTMLIFrameElement.prototype');
   domOverrides.add('SharedWorker.prototype');
 
@@ -115,7 +115,7 @@ export default function loadDomOverrides(
   });
 
   domOverrides.registerWorkerOverrides(
-    'console.debug',
+    'console',
     'navigator.deviceMemory',
     'navigator.hardwareConcurrency',
     'navigator',


### PR DESCRIPTION
Console is being called while this is not the case in normal chrome (easy to see with error stack getter). This makes it very easy to flag unblocked as a bot. This PR removes all console logging to be safe on the fingerprint side, but this does come at a pretty big cost for usability (no logs in devtools).

I'm still investigation if there is an option to increase user experience without being detected.