### PR TITLE
fix: don't crash on prototype overflow

### DIFF
--- a/plugins/default-browser-emulator/injected-scripts/_proxyUtils.ts
+++ b/plugins/default-browser-emulator/injected-scripts/_proxyUtils.ts
@@ -225,7 +225,11 @@ function internalCreateFnProxy(
     apply: onApply,
     setPrototypeOf(target: any, newPrototype: any): boolean {
       let protoTarget = newPrototype;
-      if (newPrototype === proxy || newPrototype?.__proto__ === proxy) {
+      let newPrototypeProto;
+      try {
+        newPrototypeProto = newPrototype?.__proto__ ;
+      } catch {}
+      if (newPrototype === proxy || newPrototypeProto === proxy) {
         protoTarget = target;
       }
       let isFromObjectSetPrototypeOf = isObjectSetPrototypeOf > 0;

--- a/plugins/default-browser-emulator/injected-scripts/_proxyUtils.ts
+++ b/plugins/default-browser-emulator/injected-scripts/_proxyUtils.ts
@@ -227,7 +227,7 @@ function internalCreateFnProxy(
       let protoTarget = newPrototype;
       let newPrototypeProto;
       try {
-        newPrototypeProto = newPrototype?.__proto__ ;
+        newPrototypeProto = newPrototype?.__proto__;
       } catch {}
       if (newPrototype === proxy || newPrototypeProto === proxy) {
         protoTarget = target;

--- a/plugins/default-browser-emulator/test/detection.test.ts
+++ b/plugins/default-browser-emulator/test/detection.test.ts
@@ -355,6 +355,32 @@ test('should properly emulate memory', async () => {
   expect(heapSizeGb).toBeLessThanOrEqual(deviceMemory);
 });
 
+test('should not overflow on console.debug', async () => {
+  const agent = pool.createAgent({
+    logger,
+  });
+  Helpers.needsClosing.push(agent);
+  const page = await agent.newPage();
+  page.on('console', console.log);
+  await page.goto(`${koaServer.baseUrl}`);
+  const { stack } = await page.evaluate<any>(`(() => {
+    const m = new Proxy(console.debug, { 
+        apply() { 
+            return Reflect.apply(...arguments) 
+        }
+    });
+
+    try {
+      Object.setPrototypeOf(console.debug, m)
+      Object.setPrototypeOf(console.debug, m)
+      return { stack: 'no error' }
+    } catch(err) {
+      return { stack: err.stack };
+    }
+})()`);
+  expect(stack).toBe('no error');
+});
+
 test('stack overflow test should match chrome', async () => {
   const agent = pool.createAgent({
     logger,


### PR DESCRIPTION
It seems like this overflow is expected on `__proto__` so just making sure it doesn't crash this function seems ok? It removes the behaviour of replacing `protoTarget` with `target`. But afaik this was already not working here.